### PR TITLE
Refactor Sleep Goal UI: Move Button Below Description and Remove Redundant Header Button

### DIFF
--- a/static/css/historical.css
+++ b/static/css/historical.css
@@ -500,3 +500,19 @@
 .table-hover tbody tr:hover .mood.exhausted {
   color: #fff !important;
 }
+
+.btn-set-goal {
+  background-color: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  font-size: 0.85rem;
+  padding: 6px 16px;
+  border-radius: 0.5rem;
+  transition: background-color 0.3s ease;
+  display: inline-block;
+}
+
+.btn-set-goal:hover {
+  background-color: var(--primary);
+  color: #fff;
+}

--- a/templates/Homepage/demo.html
+++ b/templates/Homepage/demo.html
@@ -204,14 +204,7 @@
             class="d-sm-flex align-items-center justify-content-between mb-4"
           >
             <h1 class="h3 mb-0">Sleep History</h1>
-            <a
-              href="#"
-              class="d-none d-sm-inline-block btn btn-primary shadow-sm"
-              data-bs-toggle="modal"
-              data-bs-target="#sleepGoalModal"
-            >
-              <i class="fas fa-bed fa-sm text-white-50 me-2"></i>Set Sleep Goal
-            </a>
+            
           </div>
 
           <!-- Sleep Goal Card -->
@@ -226,7 +219,20 @@
                         <span id="currentGoalValue">8.0</span> hrs
                       </div>
                       <p class="text-white">Set your ideal sleep duration</p>
-                    </div>
+<div class="mt-2">
+  <button
+    class="btn btn-set-goal"
+    data-bs-toggle="modal"
+    data-bs-target="#sleepGoalModal"
+  >
+    <i class="fas fa-bed me-1"></i> Set Sleep Goal
+  </button>
+</div>
+</div> <!-- closes col-md-4 -->
+
+                    
+                    
+
                     <div class="col-md-4 text-center">
                       <div class="progress-circle">
                         <svg height="120" width="120" viewBox="0 0 120 120">


### PR DESCRIPTION
This PR improves the layout of the Sleep Goal section on the demo page by:

Removing the redundant "Set Sleep Goal" button from the top-right header.

Adding a contextually placed "Set Goal" button below the "Set your ideal sleep duration" text.

Ensuring better visual alignment and avoiding overlap with other components.

Maintaining responsiveness and consistent styling across screen sizes.

This change enhances UI clarity and improves user experience on the Sleep History page.

Fixed #53 