### PR TITLE
Improve text visibility on dashboard stats cards

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -356,7 +356,7 @@
 }
 
 .stats-card .text-muted {
-  color: var(--text-muted);
+  color: #cccccc !important;
   font-size: 0.8rem;
 }
 


### PR DESCRIPTION
This PR addresses UI readability concerns for small text labels under dashboard statistic cards:


Fixes#62