### PR TITLE
Fix misalignment of "Sleep History" heading in demo page

### DIFF
--- a/templates/Homepage/demo.html
+++ b/templates/Homepage/demo.html
@@ -204,11 +204,10 @@
         </nav>
 
         <div class="container-fluid">
-          <div
-            class="d-sm-flex align-items-center justify-content-between mb-4"
-          >
-            <h1 class="h3 mb-0">Sleep History</h1>
+          <div class="container-fluid px-4 py-3">
+            <h1 class="h3 mb-3 text-light">Sleep History</h1>
           </div>
+          
 
           <!-- Sleep Goal Card -->
           <div class="row mb-4">


### PR DESCRIPTION
This PR resolves a visual layout issue on the demo page where the heading "Sleep History" appeared too close to the left edge and lacked vertical spacing.


Closes #66 