### PR TITLE
Remove Unused Notification and Search Icons

### DIFF
--- a/templates/Homepage/dashboard.html
+++ b/templates/Homepage/dashboard.html
@@ -111,53 +111,7 @@
             </button>
 
             <ul class="navbar-nav flex-row ms-auto">
-              <li class="nav-item me-3">
-                <a class="nav-link" href="#">
-                  <i class="fas fa-search"></i>
-                </a>
-              </li>
-              <li class="nav-item dropdown me-3">
-                <a
-                  class="nav-link"
-                  href="#"
-                  id="navbarDropdown"
-                  role="button"
-                  data-bs-toggle="dropdown"
-                  aria-expanded="false"
-                >
-                  <i class="fas fa-bell"></i>
-                  <span
-                    class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
-                  >
-                    3
-                  </span>
-                </a>
-                <ul
-                  class="dropdown-menu dropdown-menu-end"
-                  aria-labelledby="navbarDropdown"
-                >
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-trophy me-2"></i> Sleep goal
-                      achieved!</a
-                    >
-                  </li>
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-exclamation-circle me-2"></i> Record
-                      yesterday's sleep</a
-                    >
-                  </li>
-                  <li><hr class="dropdown-divider" /></li>
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-envelope me-2"></i> Weekly report
-                      ready</a
-                    >
-                  </li>
-                </ul>
-              </li>
-              <li class="nav-item dropdown">
+                           <li class="nav-item dropdown">
                 <a
                   class="nav-link d-flex align-items-center"
                   href="#"

--- a/templates/Homepage/demo.html
+++ b/templates/Homepage/demo.html
@@ -109,52 +109,8 @@
             </button>
 
             <ul class="navbar-nav flex-row ms-auto">
-              <li class="nav-item me-3">
-                <a class="nav-link" href="#">
-                  <i class="fas fa-search"></i>
-                </a>
-              </li>
-              <li class="nav-item dropdown me-3">
-                <a
-                  class="nav-link"
-                  href="#"
-                  id="navbarDropdown"
-                  role="button"
-                  data-bs-toggle="dropdown"
-                  aria-expanded="false"
-                >
-                  <i class="fas fa-bell"></i>
-                  <span
-                    class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
-                  >
-                    3
-                  </span>
-                </a>
-                <ul
-                  class="dropdown-menu dropdown-menu-end"
-                  aria-labelledby="navbarDropdown"
-                >
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-trophy me-2"></i> Sleep goal
-                      achieved!</a
-                    >
-                  </li>
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-exclamation-circle me-2"></i> Record
-                      yesterday's sleep</a
-                    >
-                  </li>
-                  <li><hr class="dropdown-divider" /></li>
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-envelope me-2"></i> Weekly report
-                      ready</a
-                    >
-                  </li>
-                </ul>
-              </li>
+              
+                    
               <li class="nav-item dropdown">
                 <a
                   class="nav-link d-flex align-items-center"


### PR DESCRIPTION
This PR removes the bell (notifications) and search icons from the navbar in the following templates:
dashboard.html
demo.html


Why This Was Needed
 These elements had no backend or frontend functionality
 Simplifies the user interface
 Avoids confusion and visual clutter

Fixes #71 

