### PR TITLE
Remove Statistics Cards from Profile Page

### DIFF
--- a/routes/profile.py
+++ b/routes/profile.py
@@ -14,50 +14,6 @@ def view_profile():
     # Get user achievements
     achievements = Achievement.query.filter_by(user_id=current_user.id).all()
     
-    # Count total sleep entries
-    total_entries = SleepRecord.query.filter_by(user_id=current_user.id).count()
-    
-    # Calculate current streak
-    # Get dates of all records
-    sleep_dates_query = db.session.query(func.date(SleepRecord.date)).filter_by(user_id=current_user.id).order_by(SleepRecord.date.desc()).all()
-    sleep_dates = [date[0] for date in sleep_dates_query]
-    
-    # Calculate streak
-    current_streak = 0
-    if sleep_dates:
-        today = datetime.now().date()
-        # Check if there's a record for today or yesterday
-        if today in sleep_dates or (today - timedelta(days=1)) in sleep_dates:
-            current_streak = 1  # Start with 1 for the most recent day
-            check_date = today - timedelta(days=1)
-            
-            # Count back consecutively
-            for i in range(1, len(sleep_dates)):
-                if check_date in sleep_dates:
-                    current_streak += 1
-                    check_date = check_date - timedelta(days=1)
-                else:
-                    break
-    
-    # Calculate achievement points (10 points per achievement)
-    achievement_points = len([a for a in achievements if not a.is_locked]) * 10
-    
-    # Calculate goal success rate
-    latest_goal = SleepGoal.query.filter_by(user_id=current_user.id).order_by(SleepGoal.created_at.desc()).first()
-    goal_success_rate = 0
-    
-    if latest_goal and total_entries > 0:
-        goal_hours = latest_goal.target_hours + (latest_goal.target_minutes / 60)
-        
-        # Get all records to calculate average
-        sleep_records = SleepRecord.query.filter_by(user_id=current_user.id).all()
-        if sleep_records:
-            total_duration = sum(record.duration_hours for record in sleep_records)
-            avg_duration = total_duration / len(sleep_records)
-            
-            # Goal success rate as percentage of average duration vs goal
-            goal_success_rate = int(min(100, (avg_duration / goal_hours) * 100))
-    
     # Add some default locked achievements for display if the user doesn't have any
     default_achievements = []
     if not achievements:
@@ -72,11 +28,7 @@ def view_profile():
         'Homepage/profile.html', 
         user=current_user,
         achievements=achievements,
-        default_achievements=default_achievements,
-        total_entries=total_entries,
-        current_streak=current_streak,
-        achievement_points=achievement_points,
-        goal_success_rate=goal_success_rate
+        default_achievements=default_achievements
     )
 
 @profile.route('/profile/edit', methods=['GET', 'POST'])

--- a/static/js/Homepage/dashboard.js
+++ b/static/js/Homepage/dashboard.js
@@ -28,176 +28,6 @@ $(document).ready(function () {
     }
   });
 
-  // Initialize Sleep Trend Chart if the element exists
-  const sleepTrendChartElement = document.getElementById("sleepTrendChart");
-  if (sleepTrendChartElement) {
-    const sleepTrendChart = sleepTrendChartElement.getContext("2d");
-
-    const sleepTrendData = {
-      labels: ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
-      datasets: [
-        {
-          label: "Sleep Duration",
-          data: [7.5, 6.5, 7.5, 6, 8.5, 7.5, 7.5],
-          backgroundColor: "rgba(94, 114, 228, 0.2)",
-          borderColor: "rgba(94, 114, 228, 1)",
-          borderWidth: 2,
-          pointRadius: 5,
-          pointBackgroundColor: "rgba(94, 114, 228, 1)",
-          pointBorderColor: "#fff",
-          tension: 0.3,
-        },
-        {
-          label: "Sleep Goal",
-          data: [8, 8, 8, 8, 8, 8, 8],
-          borderColor: "rgba(46, 203, 186, 0.8)",
-          borderWidth: 2,
-          borderDash: [5, 5],
-          fill: false,
-          pointRadius: 0,
-        },
-      ],
-    };
-
-    const sleepTrendConfig = {
-      type: "line",
-      data: sleepTrendData,
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          legend: {
-            position: "top",
-            labels: {
-              color: "#f8f9fa",
-              font: {
-                family: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif",
-                size: 12,
-              },
-            },
-          },
-          tooltip: {
-            backgroundColor: "rgba(45, 45, 45, 0.9)",
-            titleColor: "#f8f9fa",
-            bodyColor: "#f8f9fa",
-            borderColor: "#424242",
-            borderWidth: 1,
-            padding: 12,
-          },
-        },
-        scales: {
-          x: {
-            grid: {
-              color: "rgba(66, 66, 66, 0.5)",
-              borderColor: "#424242",
-              borderDash: [2, 2],
-            },
-            ticks: {
-              color: "#adb5bd",
-              font: {
-                family: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif",
-                size: 11,
-              },
-            },
-          },
-          y: {
-            beginAtZero: true,
-            max: 12,
-            grid: {
-              color: "rgba(66, 66, 66, 0.5)",
-              borderColor: "#424242",
-              borderDash: [2, 2],
-            },
-            ticks: {
-              color: "#adb5bd",
-              font: {
-                family: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif",
-                size: 11,
-              },
-              stepSize: 2,
-            },
-          },
-        },
-      },
-    };
-
-    new Chart(sleepTrendChart, sleepTrendConfig);
-  }
-
-  // Initialize Sleep Quality Chart if the element exists
-  const sleepQualityChartElement = document.getElementById("sleepQualityChart");
-  if (sleepQualityChartElement) {
-    const sleepQualityChart = sleepQualityChartElement.getContext("2d");
-
-    const sleepQualityData = {
-      labels: ["Excellent", "Good", "Fair", "Poor"],
-      datasets: [
-        {
-          data: [8, 12, 3, 2],
-          backgroundColor: [
-            "rgba(46, 209, 151, 0.8)",
-            "rgba(54, 195, 216, 0.8)",
-            "rgba(255, 193, 7, 0.8)",
-            "rgba(255, 71, 87, 0.8)",
-          ],
-          borderColor: [
-            "rgba(46, 209, 151, 1)",
-            "rgba(54, 195, 216, 1)",
-            "rgba(255, 193, 7, 1)",
-            "rgba(255, 71, 87, 1)",
-          ],
-          borderWidth: 1,
-        },
-      ],
-    };
-
-    const sleepQualityConfig = {
-      type: "doughnut",
-      data: sleepQualityData,
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        plugins: {
-          legend: {
-            position: "bottom",
-            labels: {
-              color: "#f8f9fa",
-              font: {
-                family: "'Segoe UI', Tahoma, Geneva, Verdana, sans-serif",
-                size: 11,
-              },
-              boxWidth: 12,
-              padding: 15,
-            },
-          },
-          tooltip: {
-            backgroundColor: "rgba(45, 45, 45, 0.9)",
-            titleColor: "#f8f9fa",
-            bodyColor: "#f8f9fa",
-            borderColor: "#424242",
-            borderWidth: 1,
-            padding: 12,
-            callbacks: {
-              label: function (context) {
-                const label = context.label || "";
-                const value = context.raw || 0;
-                const total = context.dataset.data.reduce(
-                  (acc, data) => acc + data,
-                  0
-                );
-                const percentage = Math.round((value / total) * 100);
-                return `${label}: ${percentage}% (${value} nights)`;
-              },
-            },
-          },
-        },
-        cutout: "70%",
-      },
-    };
-
-    new Chart(sleepQualityChart, sleepQualityConfig);
-  }
-
   // Set default values for sleep goal form
   const hoursSelect = document.getElementById("sleepGoalHours");
   const minutesSelect = document.getElementById("sleepGoalMinutes");
@@ -234,8 +64,6 @@ $(document).ready(function () {
     // Calculate total hours
     const totalHours = sleepGoalHours + sleepGoalMinutes / 60;
 
-    updateChartGoalLine(totalHours);
-
     // Show success message
     showToast(
       "Sleep goal updated successfully! Your goal is now " +
@@ -251,18 +79,6 @@ $(document).ready(function () {
       $("#sleepGoalForm").submit();
     }, 500); // 0.5sec
   });
-
-  // Function to update the goal line in the chart
-  function updateChartGoalLine(goalHours) {
-    const chart = Chart.getChart("sleepTrendChart");
-    if (chart) {
-      // Update the second dataset (goal line)
-      chart.data.datasets[1].data = Array(chart.data.labels.length).fill(
-        goalHours
-      );
-      chart.update();
-    }
-  }
 
   // Function to display toast notifications
   function showToast(message, type = "info") {

--- a/templates/Homepage/dashboard.html
+++ b/templates/Homepage/dashboard.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dashboard | Sleep Tracker</title>
-    
+
     {% include 'Settings/theme_preload.html' %}
-    
+
     <!-- Bootstrap CSS -->
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
@@ -111,7 +111,7 @@
             </button>
 
             <ul class="navbar-nav flex-row ms-auto">
-                           <li class="nav-item dropdown">
+              <li class="nav-item dropdown">
                 <a
                   class="nav-link d-flex align-items-center"
                   href="#"
@@ -136,12 +136,16 @@
                   aria-labelledby="userDropdown"
                 >
                   <li>
-                    <a class="dropdown-item" href="{{ url_for('profile.view_profile') }}"
+                    <a
+                      class="dropdown-item"
+                      href="{{ url_for('profile.view_profile') }}"
                       ><i class="fas fa-user me-2"></i> Profile</a
                     >
                   </li>
                   <li>
-                    <a class="dropdown-item" href="{{ url_for('settings.view_settings') }}"
+                    <a
+                      class="dropdown-item"
+                      href="{{ url_for('settings.view_settings') }}"
                       ><i class="fas fa-cog me-2"></i> Settings</a
                     >
                   </li>
@@ -234,7 +238,9 @@
             <div
               class="card-header py-3 d-flex justify-content-between align-items-center"
             >
-              <h6 class="m-0 font-weight-bold">Sleep Trend</h6>
+              <h6 class="m-0 font-weight-bold">
+                Sleep Trend (subjective judgment)
+              </h6>
               <div class="btn-group" role="group">
                 <button
                   type="button"
@@ -370,7 +376,7 @@
                     <div class="feature-icon">
                       <i class="fas fa-chart-pie"></i>
                     </div>
-                    <h3>Sleep Quality</h3>
+                    <h3>Sleep Quality (subjective judgment)</h3>
                     <div class="row">
                       <div class="col-md-3 text-center mb-3">
                         <div class="quality-circle excellent">

--- a/templates/Homepage/profile.html
+++ b/templates/Homepage/profile.html
@@ -26,48 +26,8 @@
     <!-- Theme JS -->
     <script src="{{ url_for('static', filename='js/Settings/theme.js') }}"></script>
     
-    <!-- Pass flash messages to JavaScript -->
     <script>
-      document.addEventListener('DOMContentLoaded', function() {
-        const flashMessages = JSON.parse('{{ get_flashed_messages(with_categories=true) | tojson }}');
-        
-        // Display flash messages if any
-        if (flashMessages && flashMessages.length > 0) {
-          flashMessages.forEach(function(flash) {
-            const category = flash[0] !== 'message' ? flash[0] : 'info';
-            const message = flash[1];
-            
-            // Use toastr or any other notification library you're using
-            // This example assumes you're using Bootstrap alerts
-            showAlert(category, message);
-          });
-        }
-        
-        function showAlert(category, message) {
-          const alertContainer = document.createElement('div');
-          alertContainer.className = `alert alert-${category} alert-dismissible fade show`;
-          alertContainer.setAttribute('role', 'alert');
-          
-          alertContainer.innerHTML = `
-            ${message}
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-          `;
-          
-          // Insert at the top of the content area
-          const mainContent = document.querySelector('.main-content');
-          if (mainContent) {
-            mainContent.insertBefore(alertContainer, mainContent.firstChild);
-          }
-          
-          // Auto-dismiss after 5 seconds
-          setTimeout(function() {
-            alertContainer.classList.remove('show');
-            setTimeout(function() {
-              alertContainer.remove();
-            }, 150);
-          }, 5000);
-        }
-      });
+       window.flashes = JSON.parse('{{ get_flashed_messages(with_categories=true) | tojson }}');
     </script>
   </head>
   <body class="profile-page">
@@ -96,12 +56,28 @@
               Dashboard
             </a>
           </li>
+
+          <li>
+            <a href="{{ url_for('sleep.record_sleep') }}">
+              <i class="fas fa-plus-circle"></i>
+              Record Sleep
+            </a>
+          </li>
+
           <li>
             <a href="{{ url_for('sleep.sleep_history') }}">
               <i class="fas fa-history"></i>
               Sleep History
             </a>
           </li>
+
+          <li>
+            <a href="{{ url_for('report.view_report') }}">
+              <i class="fas fa-chart-line"></i>
+              Sleep Reports
+            </a>
+          </li>
+
           <li>
             <a href="{{ url_for('settings.view_settings') }}">
               <i class="fas fa-cog"></i>
@@ -276,89 +252,6 @@
                           <p>{{ current_user.bio }}</p>
                         </div>
                       </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Sleep Stats Cards -->
-          <div class="row mb-4">
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-primary shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div
-                        class="text-xs font-weight-bold text-primary text-uppercase mb-1"
-                      >
-                        Total Entries
-                      </div>
-                      <div class="h5 mb-0 font-weight-bold">{{ total_entries }}</div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-calendar fa-2x text-gray-300"></i>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-success shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div
-                        class="text-xs font-weight-bold text-success text-uppercase mb-1"
-                      >
-                        Current Streak
-                      </div>
-                      <div class="h5 mb-0 font-weight-bold">{{ current_streak }} days</div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-trophy fa-2x text-gray-300"></i>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-info shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div
-                        class="text-xs font-weight-bold text-info text-uppercase mb-1"
-                      >
-                        Achievement Points
-                      </div>
-                      <div class="h5 mb-0 font-weight-bold">{{ achievement_points }}</div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-medal fa-2x text-gray-300"></i>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div class="col-xl-3 col-md-6 mb-4">
-              <div class="card border-left-warning shadow h-100 py-2">
-                <div class="card-body">
-                  <div class="row no-gutters align-items-center">
-                    <div class="col mr-2">
-                      <div
-                        class="text-xs font-weight-bold text-warning text-uppercase mb-1"
-                      >
-                        Goal Success Rate
-                      </div>
-                      <div class="h5 mb-0 font-weight-bold">{{ goal_success_rate }}%</div>
-                    </div>
-                    <div class="col-auto">
-                      <i class="fas fa-bullseye fa-2x text-gray-300"></i>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Issue
Resolves #84 
Changes Overview
This PR removes the statistics cards (Total Entries, Current Streak, Achievement Points, Goal Success Rate) from the profile page to create a cleaner, more focused user experience. The corresponding backend calculations have also been removed to improve page load performance.
Implementation Details

Removed statistics cards HTML section from profile page template
Eliminated backend calculation logic for these metrics in the profile route
Updated JavaScript to ensure proper sidebar toggle functionality
Maintained visual balance of the profile page after removing elements

Files Changed

routes/profile.py: Removed statistics calculation code and template variables
templates/Homepage/profile.html: Removed statistics cards HTML section
static/js/Homepage/dashboard.js: Updated sidebar toggle functionality
templates/Homepage/dashboard.html: Adjusted related components


Notes
This change is part of our effort to streamline the user interface and focus on the most essential features based on user feedback. The removed metrics are still available on the dashboard for users who need this information.