### PR TITLE
Remove Search and Notification Icons from Profile Page Navbar

### DIFF
--- a/templates/Homepage/profile.html
+++ b/templates/Homepage/profile.html
@@ -109,53 +109,8 @@
             </button>
 
             <ul class="navbar-nav flex-row ms-auto">
-              <li class="nav-item me-3">
-                <a class="nav-link" href="#">
-                  <i class="fas fa-search"></i>
-                </a>
-              </li>
-              <li class="nav-item dropdown me-3">
-                <a
-                  class="nav-link"
-                  href="#"
-                  id="navbarDropdown"
-                  role="button"
-                  data-bs-toggle="dropdown"
-                  aria-expanded="false"
-                >
-                  <i class="fas fa-bell"></i>
-                  <span
-                    class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
-                  >
-                    3
-                  </span>
-                </a>
-                <ul
-                  class="dropdown-menu dropdown-menu-end"
-                  aria-labelledby="navbarDropdown"
-                >
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-trophy me-2"></i> Sleep goal
-                      achieved!</a
-                    >
-                  </li>
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-exclamation-circle me-2"></i> Record
-                      yesterday's sleep</a
-                    >
-                  </li>
-                  <li><hr class="dropdown-divider" /></li>
-                  <li>
-                    <a class="dropdown-item" href="#"
-                      ><i class="fas fa-envelope me-2"></i> Weekly report
-                      ready</a
-                    >
-                  </li>
-                </ul>
-              </li>
               <li class="nav-item dropdown">
+                </li>
                 <a
                   class="nav-link d-flex align-items-center"
                   href="#"


### PR DESCRIPTION
This pull request removes the search icon and notification bell from the profile page navbar. These UI elements were not functional on this page and created visual clutter.

Closes #93 

